### PR TITLE
Fix ASN1 Boolean identifier

### DIFF
--- a/asn1.lisp
+++ b/asn1.lisp
@@ -190,7 +190,7 @@
 ;; -------------- booleans ---------------
 
 (defun encode-boolean (stream value)
-  (encode-identifier stream 0)
+  (encode-identifier stream 1)
   (encode-length stream 1)
   (write-byte (if value #xff 0) stream))
 


### PR DESCRIPTION
ASN1 Boolean identifier set to value 1 according to the ITU-T X.690.