### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/cerberus-kdc.asd
+++ b/cerberus-kdc.asd
@@ -1,0 +1,18 @@
+;;;; Copyright (c) Frank James 2015 <frank.a.james@gmail.com>
+;;;; This code is licensed under the MIT license.
+
+(defsystem :cerberus-kdc
+  :name "cerberus-kdc"
+  :author "Frank James <frank.a.james@gmail.com>"
+  :description "Kerberos KDC server for cerberus."
+  :license "MIT"
+  :components
+  ((:module :kdc
+            :pathname "kdc"
+            :components 
+            ((:file "package")
+             (:file "log" :depends-on ("package"))
+             (:file "database" :depends-on ("package"))
+             (:file "server" :depends-on ("log" "database"))
+             (:file "kdc" :depends-on ("server")))))
+  :depends-on (:cerberus :pounds :frpc))

--- a/cerberus.asd
+++ b/cerberus.asd
@@ -1,7 +1,7 @@
 ;;;; Copyright (c) Frank James 2015 <frank.a.james@gmail.com>
 ;;;; This code is licensed under the MIT license.
 
-(asdf:defsystem :cerberus
+(defsystem :cerberus
   :name "cerberus"
   :author "Frank James <frank.a.james@gmail.com>"
   :description "Kerberos implementation, provides support to the glass API."
@@ -21,21 +21,3 @@
    (:file "gss" :depends-on ("client")))
   :depends-on (:alexandria :nibbles :flexi-streams :babel 
 	       :ironclad :usocket :glass))
-
-(asdf:defsystem :cerberus-kdc
-  :name "cerberus-kdc"
-  :author "Frank James <frank.a.james@gmail.com>"
-  :description "Kerberos KDC server for cerberus."
-  :license "MIT"
-  :components
-  ((:module :kdc
-            :pathname "kdc"
-            :components 
-            ((:file "package")
-             (:file "log" :depends-on ("package"))
-             (:file "database" :depends-on ("package"))
-             (:file "server" :depends-on ("log" "database"))
-             (:file "kdc" :depends-on ("server")))))
-  :depends-on (:cerberus :pounds :frpc))
-
-


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
